### PR TITLE
Add Fleet recipe for Caffeine package

### DIFF
--- a/Caffeine.fleet.recipe.yaml
+++ b/Caffeine.fleet.recipe.yaml
@@ -1,0 +1,32 @@
+Description: 'Builds Caffeine.pkg and uploads to Fleet'
+Identifier: com.github.kitzy.fleet.Caffeine
+Input:
+  NAME: Caffeine
+MinimumVersion: '2.0'
+ParentRecipe: com.github.homebysix.pkg.Caffeine
+Process:
+- Arguments:
+    automatic_install: false
+    defaults_path: fleet.defaults.yaml
+    fleet_api_token: "%FLEET_API_TOKEN%"
+    github_token: "%FLEET_GITOPS_GITHUB_TOKEN%"
+    pkg_path: "%pkg_path%"
+    platform: darwin
+    self_service: true
+    software_slug: caffeine
+    software_title: "%NAME%"
+    version: "%version%"
+    fleet_api_base: "https://fleet.kitzy.net"
+    team_id: 4
+    git_repo_url: "https://github.com/kitzy/fleet-gitops"
+    git_base_branch: "main"
+    git_author_name: "autopkg-bot"
+    git_author_email: "autopkg-bot@kitzy.net"
+    team_yaml_path: "teams/workstations.yml"
+    software_dir: "lib/macos/software"
+    package_yaml_suffix: ".yml"
+    team_yaml_package_path_prefix: "../lib/macos/software/"
+    pr_labels: ["autopkg"]          # or ["autopkg","software-update"]
+    branch_prefix: "autopkg"
+    PR_REVIEWER: "{{ PR_REVIEWER }}"
+  Processor: FleetGitOpsUploader


### PR DESCRIPTION
Introduces Caffeine.fleet.recipe.yaml to automate building and uploading the Caffeine.pkg to Fleet using FleetGitOpsUploader. Includes configuration for GitHub integration, API tokens, and team settings.