### PR TITLE
Remove push trigger from lint and validate workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,6 @@
 name: Code Quality
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,14 +9,6 @@ on:
       - '*.yml'
       - 'requirements.txt'
       - '.github/workflows/**'
-  push:
-    branches: [ main ]
-    paths:
-      - '*.py'
-      - '*.yaml'
-      - '*.yml'
-      - 'requirements.txt'
-      - '.github/workflows/**'
 
 jobs:
   validate-python:


### PR DESCRIPTION
Eliminate the push trigger from the workflows to streamline the validation process, focusing only on pull requests.