### PR TITLE
Fix processor stub recipe format

### DIFF
--- a/processors/FleetGitOpsUploader.recipe
+++ b/processors/FleetGitOpsUploader.recipe
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?><?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+
+<plist version="1.0"><plist version="1.0">
+
+<dict><dict>
+
+	<key>Description</key>	<key>Description</key>
+
+	<string>This is a stub recipe that can be used as a reference when referring to the FleetGitOpsUploader shared processor.</string>	<string>This is a stub recipe that can be used as a reference when referring to the FleetGitOpsUploader shared processor.</string>
+
+	<key>Identifier</key>	<key>Identifier</key>
+
+	<string>com.github.kitzy.FleetGitOpsUploader</string>	<string>com.github.kitzy.FleetGitOpsUploader</string>
+
+	<key>Input</key>	<key>Input</key>
+
+	<dict/>	<dict/>
+
+	<key>MinimumVersion</key>	<key>MinimumVersion</key>
+
+	<string>2.0</string>	<string>2.0</string>
+
+	<key>Process</key>	<key>Process</key>
+
+	<array/>	<array/>
+
+</dict></dict>
+
+</plist></plist>

--- a/processors/FleetGitOpsUploader.recipe.yaml
+++ b/processors/FleetGitOpsUploader.recipe.yaml
@@ -1,7 +1,0 @@
-Description: Stub recipe for the FleetGitOpsUploader shared processor.
-Identifier: com.github.kitzy.sharedprocessor.FleetGitOpsUploader
-MinimumVersion: '2.0'
-Input:
-  NAME: FleetGitOpsUploader
-Process:
-- Processor: FleetGitOpsUploader


### PR DESCRIPTION
## Problem
AutoPkg was failing with 'Unknown processor FleetGitOpsUploader' error when running recipes.

## Root Cause
The processor stub recipe was in YAML format, but AutoPkg requires XML/plist format with .recipe extension for shared processor stub recipes.

## Solution
- Convert  to 
- Use proper XML/plist format following AutoPkg conventions
- Matches the pattern used by other shared processors in autopkg/homebysix-recipes

## Testing
After this change, AutoPkg should be able to discover and use the FleetGitOpsUploader processor in recipes.

## References
- Follows the same pattern as other processors like FindAndReplace in homebysix-recipes
- Uses standard AutoPkg XML/plist format for recipe files