### PR TITLE
Fix version handling: Use AutoPkg version instead of Fleet default

### DIFF
--- a/FleetGitOpsUploader/FleetGitOpsUploader.py
+++ b/FleetGitOpsUploader/FleetGitOpsUploader.py
@@ -343,7 +343,8 @@ class FleetGitOpsUploader(Processor):
         title_id = software_package.get("title_id")
         installer_id = software_package.get("installer_id")
         hash_sha256 = software_package.get("hash_sha256")
-        returned_version = software_package.get("version") or version
+        # Use our version, not Fleet's returned version which may be incorrect
+        returned_version = version
 
         # Prepare repo in a temp dir
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Critical Bug Fix: Incorrect Version in GitOps PRs

**Problem:** AutoPkg correctly detects GPG Suite version 2023.3, but GitOps PR shows version 1.0 instead.

**Root Cause:** Processor was using Fleet API's returned version field (defaulting to 1.0) instead of AutoPkg's detected version.

**Solution:** Always use the version from AutoPkg rather than Fleet's potentially incorrect default.

**Impact:** Ensures GitOps YAML files contain accurate software versions for proper deployment tracking.

**Files Changed:** FleetGitOpsUploader/FleetGitOpsUploader.py