### PR TITLE
fix: Correct FleetGitOpsUploader processor arguments

### DIFF
--- a/1Password/1Password8.fleet.recipe.yaml
+++ b/1Password/1Password8.fleet.recipe.yaml
@@ -6,10 +6,18 @@ MinimumVersion: '2.0'
 ParentRecipe: io.github.hjuutilainen.pkg.1Password8
 Process:
 - Arguments:
+    # Core package info (from parent recipe)
+    pkg_path: '%pkg_path%'
+    software_title: '%NAME%'
+    version: '%version%'
+    
+    # Fleet API configuration (required)
+    fleet_api_base: '%FLEET_API_BASE%'
     fleet_api_token: '%FLEET_API_TOKEN%'
-    fleet_base_url: '%FLEET_BASE_URL%'
-    gitops_github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
-    gitops_repo_url: '%FLEET_GITOPS_REPO_URL%'
-    gitops_teams: '%FLEET_GITOPS_TEAMS%'
-    bundle_identifier: '%FLEET_BUNDLE_IDENTIFIER%'
+    team_id: '%FLEET_TEAM_ID%'
+    
+    # Git/GitHub configuration (required)
+    git_repo_url: '%FLEET_GITOPS_REPO_URL%'
+    github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
+    team_yaml_path: '%FLEET_TEAM_YAML_PATH%'
   Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader

--- a/1Password/1PasswordCLI.fleet.recipe.yaml
+++ b/1Password/1PasswordCLI.fleet.recipe.yaml
@@ -6,10 +6,18 @@ MinimumVersion: '2.0'
 ParentRecipe: com.github.gerardkok.pkg.1PasswordCLI
 Process:
 - Arguments:
+    # Core package info (from parent recipe)
+    pkg_path: '%pkg_path%'
+    software_title: '%NAME%'
+    version: '%version%'
+    
+    # Fleet API configuration (required)
+    fleet_api_base: '%FLEET_API_BASE%'
     fleet_api_token: '%FLEET_API_TOKEN%'
-    fleet_base_url: '%FLEET_BASE_URL%'
-    gitops_github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
-    gitops_repo_url: '%FLEET_GITOPS_REPO_URL%'
-    gitops_teams: '%FLEET_GITOPS_TEAMS%'
-    bundle_identifier: '%FLEET_BUNDLE_IDENTIFIER%'
+    team_id: '%FLEET_TEAM_ID%'
+    
+    # Git/GitHub configuration (required)
+    git_repo_url: '%FLEET_GITOPS_REPO_URL%'
+    github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
+    team_yaml_path: '%FLEET_TEAM_YAML_PATH%'
   Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader

--- a/Docker/DockerDesktop.fleet.recipe.yaml
+++ b/Docker/DockerDesktop.fleet.recipe.yaml
@@ -6,10 +6,18 @@ MinimumVersion: '2.0'
 ParentRecipe: com.github.homebysix.pkg.DockerDesktop
 Process:
 - Arguments:
+    # Core package info (from parent recipe)
+    pkg_path: '%pkg_path%'
+    software_title: '%NAME%'
+    version: '%version%'
+    
+    # Fleet API configuration (required)
+    fleet_api_base: '%FLEET_API_BASE%'
     fleet_api_token: '%FLEET_API_TOKEN%'
-    fleet_base_url: '%FLEET_BASE_URL%'
-    gitops_github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
-    gitops_repo_url: '%FLEET_GITOPS_REPO_URL%'
-    gitops_teams: '%FLEET_GITOPS_TEAMS%'
-    bundle_identifier: '%FLEET_BUNDLE_IDENTIFIER%'
+    team_id: '%FLEET_TEAM_ID%'
+    
+    # Git/GitHub configuration (required)
+    git_repo_url: '%FLEET_GITOPS_REPO_URL%'
+    github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
+    team_yaml_path: '%FLEET_TEAM_YAML_PATH%'
   Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader

--- a/Firefox/Firefox.fleet.recipe.yaml
+++ b/Firefox/Firefox.fleet.recipe.yaml
@@ -6,10 +6,18 @@ MinimumVersion: '2.0'
 ParentRecipe: com.github.autopkg.pkg.Firefox_EN
 Process:
 - Arguments:
+    # Core package info (from parent recipe)
+    pkg_path: '%pkg_path%'
+    software_title: '%NAME%'
+    version: '%version%'
+    
+    # Fleet API configuration (required)
+    fleet_api_base: '%FLEET_API_BASE%'
     fleet_api_token: '%FLEET_API_TOKEN%'
-    fleet_base_url: '%FLEET_BASE_URL%'
-    gitops_github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
-    gitops_repo_url: '%FLEET_GITOPS_REPO_URL%'
-    gitops_teams: '%FLEET_GITOPS_TEAMS%'
-    bundle_identifier: '%FLEET_BUNDLE_IDENTIFIER%'
+    team_id: '%FLEET_TEAM_ID%'
+    
+    # Git/GitHub configuration (required)
+    git_repo_url: '%FLEET_GITOPS_REPO_URL%'
+    github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
+    team_yaml_path: '%FLEET_TEAM_YAML_PATH%'
   Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader

--- a/Notion/Notion.fleet.recipe.yaml
+++ b/Notion/Notion.fleet.recipe.yaml
@@ -6,10 +6,18 @@ MinimumVersion: '2.0'
 ParentRecipe: com.github.swy.pkg.Notion
 Process:
 - Arguments:
+    # Core package info (from parent recipe)
+    pkg_path: '%pkg_path%'
+    software_title: '%NAME%'
+    version: '%version%'
+    
+    # Fleet API configuration (required)
+    fleet_api_base: '%FLEET_API_BASE%'
     fleet_api_token: '%FLEET_API_TOKEN%'
-    fleet_base_url: '%FLEET_BASE_URL%'
-    gitops_github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
-    gitops_repo_url: '%FLEET_GITOPS_REPO_URL%'
-    gitops_teams: '%FLEET_GITOPS_TEAMS%'
-    bundle_identifier: '%FLEET_BUNDLE_IDENTIFIER%'
+    team_id: '%FLEET_TEAM_ID%'
+    
+    # Git/GitHub configuration (required)
+    git_repo_url: '%FLEET_GITOPS_REPO_URL%'
+    github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
+    team_yaml_path: '%FLEET_TEAM_YAML_PATH%'
   Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader

--- a/Slack/Slack.fleet.recipe.yaml
+++ b/Slack/Slack.fleet.recipe.yaml
@@ -6,10 +6,18 @@ MinimumVersion: '2.0'
 ParentRecipe: com.github.homebysix.pkg.nebula
 Process:
 - Arguments:
+    # Core package info (from parent recipe)
+    pkg_path: '%pkg_path%'
+    software_title: '%NAME%'
+    version: '%version%'
+    
+    # Fleet API configuration (required)
+    fleet_api_base: '%FLEET_API_BASE%'
     fleet_api_token: '%FLEET_API_TOKEN%'
-    fleet_base_url: '%FLEET_BASE_URL%'
-    gitops_github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
-    gitops_repo_url: '%FLEET_GITOPS_REPO_URL%'
-    gitops_teams: '%FLEET_GITOPS_TEAMS%'
-    bundle_identifier: '%FLEET_BUNDLE_IDENTIFIER%'
+    team_id: '%FLEET_TEAM_ID%'
+    
+    # Git/GitHub configuration (required)
+    git_repo_url: '%FLEET_GITOPS_REPO_URL%'
+    github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
+    team_yaml_path: '%FLEET_TEAM_YAML_PATH%'
   Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader

--- a/VisualStudioCode/VisualStudioCode.fleet.recipe.yaml
+++ b/VisualStudioCode/VisualStudioCode.fleet.recipe.yaml
@@ -6,10 +6,18 @@ MinimumVersion: '2.0'
 ParentRecipe: com.github.amsysuk-recipes.pkg.VisualStudioCode
 Process:
 - Arguments:
+    # Core package info (from parent recipe)
+    pkg_path: '%pkg_path%'
+    software_title: '%NAME%'
+    version: '%version%'
+    
+    # Fleet API configuration (required)
+    fleet_api_base: '%FLEET_API_BASE%'
     fleet_api_token: '%FLEET_API_TOKEN%'
-    fleet_base_url: '%FLEET_BASE_URL%'
-    gitops_github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
-    gitops_repo_url: '%FLEET_GITOPS_REPO_URL%'
-    gitops_teams: '%FLEET_GITOPS_TEAMS%'
-    bundle_identifier: '%FLEET_BUNDLE_IDENTIFIER%'
+    team_id: '%FLEET_TEAM_ID%'
+    
+    # Git/GitHub configuration (required)
+    git_repo_url: '%FLEET_GITOPS_REPO_URL%'
+    github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
+    team_yaml_path: '%FLEET_TEAM_YAML_PATH%'
   Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader

--- a/Zoom/Zoom.fleet.recipe.yaml
+++ b/Zoom/Zoom.fleet.recipe.yaml
@@ -6,10 +6,18 @@ MinimumVersion: '2.0'
 ParentRecipe: com.github.homebysix.pkg.Zoom
 Process:
 - Arguments:
+    # Core package info (from parent recipe)
+    pkg_path: '%pkg_path%'
+    software_title: '%NAME%'
+    version: '%version%'
+    
+    # Fleet API configuration (required)
+    fleet_api_base: '%FLEET_API_BASE%'
     fleet_api_token: '%FLEET_API_TOKEN%'
-    fleet_base_url: '%FLEET_BASE_URL%'
-    gitops_github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
-    gitops_repo_url: '%FLEET_GITOPS_REPO_URL%'
-    gitops_teams: '%FLEET_GITOPS_TEAMS%'
-    bundle_identifier: '%FLEET_BUNDLE_IDENTIFIER%'
+    team_id: '%FLEET_TEAM_ID%'
+    
+    # Git/GitHub configuration (required)
+    git_repo_url: '%FLEET_GITOPS_REPO_URL%'
+    github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
+    team_yaml_path: '%FLEET_TEAM_YAML_PATH%'
   Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader

--- a/iTerm2/iTerm2.fleet.recipe.yaml
+++ b/iTerm2/iTerm2.fleet.recipe.yaml
@@ -6,10 +6,18 @@ MinimumVersion: '2.0'
 ParentRecipe: io.github.hjuutilainen.pkg.iTerm2
 Process:
 - Arguments:
+    # Core package info (from parent recipe)
+    pkg_path: '%pkg_path%'
+    software_title: '%NAME%'
+    version: '%version%'
+    
+    # Fleet API configuration (required)
+    fleet_api_base: '%FLEET_API_BASE%'
     fleet_api_token: '%FLEET_API_TOKEN%'
-    fleet_base_url: '%FLEET_BASE_URL%'
-    gitops_github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
-    gitops_repo_url: '%FLEET_GITOPS_REPO_URL%'
-    gitops_teams: '%FLEET_GITOPS_TEAMS%'
-    bundle_identifier: '%FLEET_BUNDLE_IDENTIFIER%'
+    team_id: '%FLEET_TEAM_ID%'
+    
+    # Git/GitHub configuration (required)
+    git_repo_url: '%FLEET_GITOPS_REPO_URL%'
+    github_token: '%FLEET_GITOPS_GITHUB_TOKEN%'
+    team_yaml_path: '%FLEET_TEAM_YAML_PATH%'
   Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader


### PR DESCRIPTION
🔧 Fix Missing Required Arguments:
- Add missing 'software_title' argument (was causing Zoom recipe failure)
- Add missing 'pkg_path' and 'version' arguments
- Use correct variable names matching working recipes

🔄 Standardize Argument Names:
- fleet_base_url → fleet_api_base
- gitops_github_token → github_token
- gitops_repo_url → git_repo_url
- gitops_teams → team_id
- bundle_identifier → team_yaml_path

✅ Fixed Recipes (9 total):
- Slack, Zoom, Docker Desktop, Firefox
- 1Password CLI, 1Password8, Visual Studio Code
- Notion, iTerm2

All recipes now match the format of working recipes
(Google Chrome, GitHub Desktop, etc.) and should pass CI.