### PR TITLE
Fix Processor path in Signal recipe

### DIFF
--- a/Signal/Signal.fleet.recipe.yaml
+++ b/Signal/Signal.fleet.recipe.yaml
@@ -31,4 +31,4 @@ Process:
     # Optional features
     skip_pkg_upload: false
     verbose_mode: true
-  Processor: FleetGitOpsUploader
+  Processor: com.github.kitzy.FleetGitOpsUploader/FleetGitOpsUploader


### PR DESCRIPTION
Update the Processor path in the Signal recipe to ensure it references the correct location.